### PR TITLE
Add hard tanh activation

### DIFF
--- a/lstm-text-generation/hardTanh.js
+++ b/lstm-text-generation/hardTanh.js
@@ -16,11 +16,8 @@ var __extends = (this && this.__extends) || (function () {
 })();
 exports.__esModule = true;
 exports.HardTanh = exports.Activation = exports.hardTanh = void 0;
-/// <amd-module name="hardTanh" />
 var tfc = require("@tensorflow/tfjs-core");
 var tfjs_core_1 = require("@tensorflow/tfjs-core");
-var tfl = require("@tensorflow/tfjs-layers");
-console.log(tfl);
 function hardTanh(x) {
     return (0, tfjs_core_1.tidy)(function () {
         var y = tfc.mul(.5, x);

--- a/lstm-text-generation/hardTanh.js
+++ b/lstm-text-generation/hardTanh.js
@@ -1,0 +1,58 @@
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+exports.HardTanh = exports.Activation = exports.hardTanh = void 0;
+/// <amd-module name="hardTanh" />
+var tfc = require("@tensorflow/tfjs-core");
+var tfjs_core_1 = require("@tensorflow/tfjs-core");
+var tfl = require("@tensorflow/tfjs-layers");
+console.log(tfl);
+function hardTanh(x) {
+    return (0, tfjs_core_1.tidy)(function () {
+        var y = tfc.mul(.5, x);
+        return tfc.clipByValue(y, -1, 1);
+    });
+}
+exports.hardTanh = hardTanh;
+var Activation = /** @class */ (function (_super) {
+    __extends(Activation, _super);
+    function Activation() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Activation.prototype.getConfig = function () {
+        return {};
+    };
+    return Activation;
+}(tfjs_core_1.serialization.Serializable));
+exports.Activation = Activation;
+/**
+ * Segment-wise linear approximation of tanh.
+ */
+var HardTanh = /** @class */ (function (_super) {
+    __extends(HardTanh, _super);
+    function HardTanh() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    HardTanh.prototype.apply = function (x) {
+        return hardTanh(x);
+    };
+    /** @nocollapse */
+    HardTanh.className = 'hardTanh';
+    return HardTanh;
+}(Activation));
+exports.HardTanh = HardTanh;
+tfjs_core_1.serialization.registerClass(HardTanh);

--- a/lstm-text-generation/hardTanh.ts
+++ b/lstm-text-generation/hardTanh.ts
@@ -1,0 +1,28 @@
+import * as tfc from '@tensorflow/tfjs-core';
+import {serialization, Tensor, tidy} from '@tensorflow/tfjs-core';
+
+export function hardTanh(x: Tensor): Tensor {
+  return tidy(() => {
+    const y = tfc.mul(.5, x);
+    return tfc.clipByValue(y, -1, 1);
+  });
+}
+
+export abstract class Activation extends serialization.Serializable {
+  abstract apply(tensor: Tensor, axis?: number): Tensor;
+  getConfig(): serialization.ConfigDict {
+    return {};
+  }
+}
+
+/**
+ * Segment-wise linear approximation of tanh.
+ */
+export class HardTanh extends Activation {
+  /** @nocollapse */
+  static readonly className = 'hardTanh';
+  apply(x: Tensor): Tensor {
+    return hardTanh(x);
+  }
+}
+serialization.registerClass(HardTanh);

--- a/lstm-text-generation/model.js
+++ b/lstm-text-generation/model.js
@@ -17,6 +17,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import {TextData} from './data';
+import {HardTanh} from './hardTanh';
 
 /**
  * Create a model for next-character prediction.
@@ -29,7 +30,9 @@ import {TextData} from './data';
  *   of `[null, sampleLen, charSetSize]` and an output shape of
  *   `[null, charSetSize]`.
  */
-export function createModel(sampleLen, charSetSize, lstmLayerSizes) {
+export function createModel(
+  sampleLen, charSetSize, lstmLayerSizes,
+  activationFunctionName, recurrentActivationFunctionName) {
   if (!Array.isArray(lstmLayerSizes)) {
     lstmLayerSizes = [lstmLayerSizes];
   }
@@ -39,6 +42,8 @@ export function createModel(sampleLen, charSetSize, lstmLayerSizes) {
     const lstmLayerSize = lstmLayerSizes[i];
     model.add(tf.layers.lstm({
       units: lstmLayerSize,
+      activation: activationFunctionName,
+      recurrentActivation: recurrentActivationFunctionName,
       returnSequences: i < lstmLayerSizes.length - 1,
       inputShape: i === 0 ? [sampleLen, charSetSize] : undefined
     }));

--- a/lstm-text-generation/train_node.js
+++ b/lstm-text-generation/train_node.js
@@ -94,6 +94,16 @@ function parseArgs() {
     help: 'LSTM layer size. Can be a single number or an array of numbers ' +
     'separated by commas (E.g., "256", "256,128")'
   });  // TODO(cais): Support
+  parser.addArgument('--activation', {
+    type: 'string',
+    defaultValue: 'tanh',
+    help: 'Activation function to use. Default: hyperbolic tangent (tanh)'
+  });
+  parser.addArgument('--recurrentActivation', {
+    type: 'string',
+    defaultValue: 'hardSigmoid',
+    help: 'Activation function to use for the recurrent step. Default: sigmoid (sigmoid).'
+  });
 
   const args = parser.parseArgs();
 
@@ -143,7 +153,8 @@ async function main() {
       args.lstmLayerSize.split(',').map(x => Number.parseInt(x));
 
   const model = createModel(
-      textData.sampleLen(), textData.charSetSize(), lstmLayerSize);
+      textData.sampleLen(), textData.charSetSize(), lstmLayerSize,
+      args.activation, args.recurrentActivation);
   compileModel(model, args.learningRate);
 
   // Get a seed text for display in the course of model training.


### PR DESCRIPTION
Implement a "hard" hyperbolic tangent activation function, that gives a segment-wise linear approximation of `tanh`.
hardTanh.ts has to be manually compiled to hardTanh.js through `tsc` to be usable. Only hardTanh.ts should be edited, hardTanh.js should be recompiled.